### PR TITLE
Make GitHub recognize *.mac as assembly language files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.mac linguist-language=assembly


### PR DESCRIPTION
Hello,

Please merge this if you'd like GitHub to recognize your `.mac` files as assembly language.

Best regards,
Lars Brinkhoff